### PR TITLE
Mercurial is required for grabbing the source for OpenJDK

### DIFF
--- a/vsetup.sh
+++ b/vsetup.sh
@@ -201,7 +201,7 @@ function _install_buildtools_centos ()
         gcc-c++ pkgconfig
         perl-libwww-perl zlib-devel libaio-devel ncurses-devel
         expat-devel pcre-devel perl-devel perl-ExtUtils-MakeMaker
-        popt-devel bzip2-devel
+        popt-devel bzip2-devel mercurial
     )
     _install "${pkgs[@]}"
 }
@@ -213,7 +213,7 @@ function _install_buildtools_ubuntu ()
         g++ pkg-config
         libwww-perl libz-dev libaio-dev libncurses-dev
         libexpat-dev libpcre3-dev libperl-dev
-        libpopt-dev libbz2-dev
+        libpopt-dev libbz2-dev mercurial
     )
     _install "${pkgs[@]}"
     # TBD: flex libreadline-dev cloog-ppl

--- a/vsetup.sh
+++ b/vsetup.sh
@@ -201,7 +201,7 @@ function _install_buildtools_centos ()
         gcc-c++ pkgconfig
         perl-libwww-perl zlib-devel libaio-devel ncurses-devel
         expat-devel pcre-devel perl-devel perl-ExtUtils-MakeMaker
-        popt-devel bzip2-devel mercurial
+        popt-devel bzip2-devel mercurial zip
     )
     _install "${pkgs[@]}"
 }
@@ -213,7 +213,7 @@ function _install_buildtools_ubuntu ()
         g++ pkg-config
         libwww-perl libz-dev libaio-dev libncurses-dev
         libexpat-dev libpcre3-dev libperl-dev
-        libpopt-dev libbz2-dev mercurial
+        libpopt-dev libbz2-dev mercurial zip
     )
     _install "${pkgs[@]}"
     # TBD: flex libreadline-dev cloog-ppl


### PR DESCRIPTION
Necessary for OpenJDK packaging
