### PR TITLE
On RHEL/CentOS systems, perl-core should be installed at all times

### DIFF
--- a/vsetup.sh
+++ b/vsetup.sh
@@ -205,7 +205,7 @@ function _install_buildtools_centos ()
         gcc-c++ pkgconfig
         perl-libwww-perl zlib-devel libaio-devel ncurses-devel
         expat-devel pcre-devel perl-devel perl-ExtUtils-MakeMaker
-        popt-devel bzip2-devel perl-Test-Simple
+        popt-devel bzip2-devel perl-Test-Simple perl-core
     )
     _install "${pkgs[@]}"
 }


### PR DESCRIPTION
We require perl-core on RHEL systems to be present for both building perl and ZCS itself.
