### PR TITLE
install add-apt-repository on 14.04

### DIFF
--- a/vsetup.sh
+++ b/vsetup.sh
@@ -104,6 +104,7 @@ function env_all_pre_ubuntu () {
     export DEBIAN_FRONTEND=noninteractive
     say "Running apt-get update -qq ..."
     apt-get update -qq
+    apt-get install software-properties-common
 }
 
 function env_all_post () { [[ "$dist" = "ubuntu" ]] && env_all_post_$dist; }


### PR DESCRIPTION
The current Ubuntu 14.04 box with the Parallels provider doesn't contain add-apt-repository.
This ensures that it is present such that the script can complete successfully.
