### PR TITLE
Socket6 is a required module for IO::Socket::IP

### DIFF
--- a/vsetup.sh
+++ b/vsetup.sh
@@ -206,6 +206,7 @@ function _install_buildtools_centos ()
         perl-libwww-perl zlib-devel libaio-devel ncurses-devel
         expat-devel pcre-devel perl-devel perl-ExtUtils-MakeMaker
         popt-devel bzip2-devel perl-Test-Simple perl-core
+        perl-Socket6
     )
     _install "${pkgs[@]}"
 }
@@ -218,6 +219,7 @@ function _install_buildtools_ubuntu ()
         libwww-perl libz-dev libaio-dev libncurses-dev
         libexpat-dev libpcre3-dev libperl-dev
         libpopt-dev libbz2-dev libtest-simple-perl
+        libsocket6-perl
     )
     _install "${pkgs[@]}"
     # TBD: flex libreadline-dev cloog-ppl


### PR DESCRIPTION
We should have the OS version of Socket6 on our vagrant VMs to satisfy its usage requirement by IO::Socket::IP, which is used by several things we use.
