### PR TITLE
Allow setting up virtualbox hashicorp/precise32 image

### DIFF
--- a/vsetup.sh
+++ b/vsetup.sh
@@ -18,9 +18,9 @@ ZIMBRA_HOME="/opt/zimbra"
 dist=$( \
   grep ^ID= /etc/os-release 2>/dev/null \
   || cut -d: -f 3 /etc/system-release-cpe 2>/dev/null \
-  || grep ^DISTRIB_ID= /etc/lsb-release \
+  || grep ^DISTRIB_ID= /etc/lsb-release 2>/dev/null \
   )
-dist="$(tr [A-Z] [a-z] <<< "$dist")"
+dist=${dist,,}
 dist=${dist#*=}
 dist=${dist#*\"}
 dist=${dist%*\"}

--- a/vsetup.sh
+++ b/vsetup.sh
@@ -18,7 +18,9 @@ ZIMBRA_HOME="/opt/zimbra"
 dist=$( \
   grep ^ID= /etc/os-release 2>/dev/null \
   || cut -d: -f 3 /etc/system-release-cpe 2>/dev/null \
+  || grep ^DISTRIB_ID= /etc/lsb-release \
   )
+dist="$(tr [A-Z] [a-z] <<< "$dist")"
 dist=${dist#*=}
 dist=${dist#*\"}
 dist=${dist%*\"}


### PR DESCRIPTION
Recognizes Ubuntu boxes using /etc/lsb-release which has DISTRIB_ID=Ubuntu
