### PR TITLE
autodetect JAVA_HOME based on the javac in the PATH

### DIFF
--- a/scripts/zimbra-profile.sh
+++ b/scripts/zimbra-profile.sh
@@ -1,3 +1,7 @@
 if [[ -n "$PATH" ]]; then
     export PATH="/opt/zimbra/bin:$PATH"
 fi
+
+if type -P javac; then
+    export JAVA_HOME=$(dirname $(dirname $(readlink -f $(type -P javac))))
+fi


### PR DESCRIPTION
A properly set JAVA_HOME is required for building Zimbra.  Without
this change one has to determine the proper path to the JDK supplied
by the OS everytime one does a vagrant ssh.

This sets the JAVA_HOME to the value corresponding to the javac found
in the PATH.  If the Zimbra javac should be used, the PATH should
be prepended with /opt/zimbra/common/bin to have it picked up.
