### PR TITLE
Install redhat-lsb-core on CentOS

### DIFF
--- a/vsetup.sh
+++ b/vsetup.sh
@@ -94,6 +94,8 @@ function env_all_pre ()
 function env_all_pre_centos () {
     say "Running yum makecache fast..."
     yum makecache fast
+    say "Installing lsb_release..."
+    yum yum install -y redhat-lsb-core
 }
 function env_all_pre_ubuntu () {
     export DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
This is required for lsb_release. Only tested with `centos/7`. Maybe a conditional is required for 6.5?
